### PR TITLE
Add __precompile__(false) to module script

### DIFF
--- a/src/QuantumStates.jl
+++ b/src/QuantumStates.jl
@@ -4,6 +4,7 @@ using UnitsToValue
 using StaticArrays
 using Parameters
 
+__precompile__(false)
 include("WignerSymbols_Simple.jl")
 include("Basis.jl")
 include("States.jl")


### PR DESCRIPTION
To prevent installation and import precompilation errors (due to function overrides)